### PR TITLE
Made openssl call stand on one line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
     - $know_host
     - $know_host_ip
 before_install:
-- openssl aes-256-cbc -K $encrypted_e9c1975ff077_key -iv $encrypted_e9c1975ff077_iv
-  -in deploy_rsa.enc -out deploy_rsa -d
+- openssl aes-256-cbc -K $encrypted_e9c1975ff077_key -iv $encrypted_e9c1975ff077_iv -in deploy_rsa.enc -out deploy_rsa -d
 - npm --version
 - phantomjs --version
 before_deploy:


### PR DESCRIPTION
Hey @persocon,

Can you try this out? I'm not sure but I think the fact that your openssl call was on 2 different lines wouldn't work on Travis CI. Mainly because your second line was starting with a dash (i.e. `-`) which is valid YAML.

Let me know how it goes.

Cheers!
